### PR TITLE
refactor: prefer functional component structure

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,6 +1,5 @@
 mod component;
 pub mod style;
-pub mod views;
 pub mod widgets;
 
 pub use component::Component;

--- a/src/components/views/mod.rs
+++ b/src/components/views/mod.rs
@@ -1,5 +1,0 @@
-pub enum View {
-    Splash,
-    Home,
-    Login,
-}

--- a/src/domain/app.rs
+++ b/src/domain/app.rs
@@ -1,58 +1,26 @@
-use crate::components::style::layout::{Dom, DomNode};
-use crate::components::views::View;
-use crate::components::widgets::Button;
 use crate::event;
 use crate::event::EventServer;
-use crate::utils;
 
-use super::router::Router;
+use super::context::*;
+use super::router::draw;
 use anyhow::Result;
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use std::cell::RefCell;
 use std::io;
-use tui::backend::{Backend, CrosstermBackend};
-use tui::layout::{Constraint, Direction, Layout};
-use tui::terminal::Frame;
+use tui::backend::CrosstermBackend;
 use tui::terminal::Terminal;
-use tui::widgets::{Block, Borders};
 
-pub struct App<B>
-where
-    B: Backend,
-{
-    terminal: RefCell<Terminal<B>>,
-    router: Router,
-}
-
-impl App<CrosstermBackend<io::Stdout>> {
-    pub fn new() -> Result<Self> {
-        let stdout = io::stdout();
-        let backend: CrosstermBackend<io::Stdout> = CrosstermBackend::new(stdout);
-        let mut terminal = Terminal::new(backend)?;
-        terminal.hide_cursor()?;
-
-        Ok(App {
-            terminal: RefCell::new(terminal),
-            router: Router::default(),
-        })
-    }
-}
-
-pub async fn render<B>(app: &mut App<B>) -> Result<()>
-where
-    B: Backend,
-{
-    app.start_ui()?;
+pub async fn render() -> Result<()> {
+    let mut terminal = init_terminal()?;
+    let context = Context::default();
 
     let mut event_server = event::EventServerCore::default();
-
     event_server.listen(event::crossterm::CrosstermEventSource);
 
     loop {
-        app.draw()?;
+        draw(&context, &mut terminal)?;
 
         match event_server.next() {
             Some(event::Event::Input(crossterm::event::Event::Key(_))) => {
@@ -64,90 +32,25 @@ where
     }
 
     event_server.stop();
+    exit_ui()?;
 
     Ok(())
 }
 
-impl<B> App<B>
-where
-    B: Backend,
-{
-    pub fn start_ui(&mut self) -> Result<()> {
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
-        enable_raw_mode()?;
-        self.terminal.get_mut().hide_cursor()?;
+fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
+    let backend: CrosstermBackend<io::Stdout> = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
 
-        Ok(())
-    }
+    execute!(io::stdout(), EnterAlternateScreen)?;
+    enable_raw_mode()?;
+    terminal.hide_cursor()?;
 
-    pub fn exit_ui(&self) -> Result<()> {
-        execute!(io::stdout(), LeaveAlternateScreen)?;
-        disable_raw_mode()?;
-
-        Ok(())
-    }
-
-    pub fn draw(&self) -> Result<()> {
-        self.terminal
-            .borrow_mut()
-            .draw(|f| match self.router.view {
-                View::Splash => self.draw_splash_view(f),
-                View::Home => self.draw_home_view(f),
-                View::Login => self.draw_login_view(f),
-            })?;
-
-        Ok(())
-    }
-
-    fn draw_splash_view(&self, f: &mut Frame<B>)
-    where
-        B: Backend,
-    {
-        self.router.dom.root.borrow_mut().container.set(f.size());
-        DomNode::add_child(
-            self.router.dom.root.clone(),
-            Box::new(Button::default()),
-            None,
-        );
-        Dom::render(f, &self.router.dom.root);
-    }
-
-    fn draw_home_view(&self, f: &mut Frame<B>)
-    where
-        B: Backend,
-    {
-    }
-
-    fn draw_login_view(&self, f: &mut Frame<B>)
-    where
-        B: Backend,
-    {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints(
-                [
-                    Constraint::Percentage(10),
-                    Constraint::Percentage(80),
-                    Constraint::Percentage(10),
-                ]
-                .as_ref(),
-            )
-            .split(f.size());
-        let block = Block::default().title("Block").borders(Borders::ALL);
-        f.render_widget(block, chunks[0]);
-        let block = Block::default().title("Block 2").borders(Borders::ALL);
-        f.render_widget(block, chunks[1]);
-    }
+    Ok(terminal)
 }
 
-impl<B> Drop for App<B>
-where
-    B: Backend,
-{
-    #[allow(unused_must_use)]
-    fn drop(&mut self) {
-        self.exit_ui();
-    }
+fn exit_ui() -> Result<()> {
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    disable_raw_mode()?;
+
+    Ok(())
 }

--- a/src/domain/context.rs
+++ b/src/domain/context.rs
@@ -1,29 +1,36 @@
-use anyhow::Result;
-use std::cell::RefCell;
-use std::io;
-use tui::backend::{Backend, CrosstermBackend};
-use tui::terminal::Terminal;
+use super::router::Route;
 
-use super::router::Router;
+pub use api::AppContext;
+pub use lib::*;
 
-pub struct Context<B>
-where
-    B: Backend,
-{
-    terminal: RefCell<Terminal<B>>,
-    router: Router,
+mod api {
+    use super::*;
+
+    pub trait AppContext {
+        fn get_route(&self) -> Route;
+    }
 }
 
-impl Context<CrosstermBackend<io::Stdout>> {
-    pub fn new() -> Result<Self> {
-        let stdout = io::stdout();
-        let backend = CrosstermBackend::new(stdout);
-        let mut terminal = Terminal::new(backend)?;
-        terminal.hide_cursor()?;
+mod lib {
+    use super::*;
 
-        Ok(Context {
-            terminal: RefCell::new(terminal),
-            router: Router::default(),
-        })
+    pub struct Context {
+        route: Route,
+    }
+
+    /// AppContext ///
+    impl AppContext for Context {
+        fn get_route(&self) -> Route {
+            self.route
+        }
+    }
+
+    /// Default ///
+    impl Default for Context {
+        fn default() -> Self {
+            Context {
+                route: Route::Splash,
+            }
+        }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,4 +1,5 @@
 mod context;
+mod pages;
 mod router;
 
 pub mod app;

--- a/src/domain/pages/login.rs
+++ b/src/domain/pages/login.rs
@@ -1,0 +1,30 @@
+use crate::domain::context::AppContext;
+
+use tui::{
+    backend::Backend,
+    layout::{Constraint, Direction, Layout},
+    terminal::Frame,
+    widgets::{Block, Borders},
+};
+
+pub fn draw_login_view<B>(context: &dyn AppContext, f: &mut Frame<B>)
+where
+    B: Backend,
+{
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints(
+            [
+                Constraint::Percentage(10),
+                Constraint::Percentage(80),
+                Constraint::Percentage(10),
+            ]
+            .as_ref(),
+        )
+        .split(f.size());
+    let block = Block::default().title("Block").borders(Borders::ALL);
+    f.render_widget(block, chunks[0]);
+    let block = Block::default().title("Block 2").borders(Borders::ALL);
+    f.render_widget(block, chunks[1]);
+}

--- a/src/domain/pages/mod.rs
+++ b/src/domain/pages/mod.rs
@@ -1,0 +1,5 @@
+mod login;
+mod splash;
+
+pub use login::*;
+pub use splash::*;

--- a/src/domain/pages/splash.rs
+++ b/src/domain/pages/splash.rs
@@ -1,0 +1,16 @@
+use tui::backend::Backend;
+use tui::terminal::Frame;
+
+use crate::components::style::layout::{Dom, DomNode};
+use crate::components::widgets::Button;
+use crate::domain::context::AppContext;
+
+pub fn draw_splash_view<B>(context: &dyn AppContext, f: &mut Frame<B>)
+where
+    B: Backend,
+{
+    let dom = Dom::default();
+    dom.root.borrow_mut().container.set(f.size());
+    DomNode::add_child(dom.root.clone(), Box::new(Button::default()), None);
+    Dom::render(f, &dom.root);
+}

--- a/src/domain/router.rs
+++ b/src/domain/router.rs
@@ -1,16 +1,26 @@
-use crate::components::style::layout::Dom;
-use crate::components::views::View;
+use super::{
+    context::AppContext,
+    pages::{draw_login_view, draw_splash_view},
+};
+use std::io::Result;
+use tui::{backend::Backend, terminal::Terminal};
 
-pub struct Router {
-    pub view: View,
-    pub dom: Dom,
+#[derive(Debug, Copy, Clone)]
+pub enum Route {
+    Splash,
+    Home,
+    Login,
 }
 
-impl Default for Router {
-    fn default() -> Self {
-        Router {
-            view: View::Splash,
-            dom: Dom::default(),
-        }
-    }
+pub fn draw<B>(context: &dyn AppContext, terminal: &mut Terminal<B>) -> Result<()>
+where
+    B: Backend,
+{
+    terminal.draw(|f| match context.get_route() {
+        Route::Splash => draw_splash_view(context, f),
+        Route::Home => (),
+        Route::Login => draw_login_view(context, f),
+    })?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,12 @@ mod domain;
 mod event;
 mod utils;
 
-use crate::domain::app::{render, App};
+use crate::domain::app;
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // main thread
-    let mut app = App::new()?;
-
-    render(&mut app).await?;
+    app::render().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Removed `App` object that was supposedly controlling the lifecycle of entire application.

Instead opt for functional components that pass a `Context` object describing the state of the system.